### PR TITLE
Added toggle-splitter#toggle-bottom-panel to fix color for Recent Tasks and Alarms

### DIFF
--- a/css/fixes.css
+++ b/css/fixes.css
@@ -123,6 +123,10 @@ bottom-panel #bottom-panel vsc-recent-tasks-and-alarms-view clr-tabs ul.nav {
     background-color: #22343c;
 }
 
+toggle-splitter#toggle-bottom-panel {
+    background-color: #22343c;
+}
+
 .nav {
     box-shadow: inset 0 -1px 0 #485764;
 }


### PR DESCRIPTION
This is to fix https://github.com/BeryJu/dark-vcenter/issues/23 I'm still on 6.5u1, so I'm not sure if this conflicts with 6.7 since it seems to already be working there

![image](https://user-images.githubusercontent.com/9137950/40080405-d442f17a-5858-11e8-8c9d-94bf599db587.png)
